### PR TITLE
GP-20324 Fix implicit limit when filtering deleted contacts

### DIFF
--- a/CRM/Banking/Matcher/Context.php
+++ b/CRM/Banking/Matcher/Context.php
@@ -240,7 +240,9 @@ class CRM_Banking_Matcher_Context {
           'id'         => ['IN' => array_keys($contact2probablility)],
           'is_deleted' => 0,
           'return'     => 'id',
-          'sequential' => 1]);
+          'sequential' => 1,
+          'options' => ['limit' => 0],
+      ]);
       foreach ($result['values'] as $contact) {
         $filtered_list[$contact['id']] = $contact2probablility[$contact['id']];
       }


### PR DESCRIPTION
This fixes an issue in `CRM_Banking_Matcher_Context::filterDeletedContacts` that causes non-deleted contacts to be removed from matches if the number of non-deleted contacts exceeds the default API3 limit of 25.